### PR TITLE
Add Custom UI Accent

### DIFF
--- a/app/src/main/java/com/hardcodecoder/pulsemusic/dialog/AccentsChooserDialogFragment.java
+++ b/app/src/main/java/com/hardcodecoder/pulsemusic/dialog/AccentsChooserDialogFragment.java
@@ -18,6 +18,7 @@ import com.hardcodecoder.pulsemusic.utils.AppSettings;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class AccentsChooserDialogFragment extends RoundedBottomSheetDialogFragment {
 
@@ -69,5 +70,11 @@ public class AccentsChooserDialogFragment extends RoundedBottomSheetDialogFragme
             recyclerView.setAdapter(adapter);
         }
         view.findViewById(R.id.choose_accents_cancel_btn).setOnClickListener(v -> dismiss());
+
+        view.findViewById(R.id.choose_accents_custom_btn).setOnClickListener(v -> {
+            CustomAccentChooserDialogFragment dialogFragment = CustomAccentChooserDialogFragment.getInstance();
+            dialogFragment.show(Objects.requireNonNull(getActivity()).getSupportFragmentManager(), CustomAccentChooserDialogFragment.TAG);
+            dismiss();
+        });
     }
 }

--- a/app/src/main/java/com/hardcodecoder/pulsemusic/dialog/CustomAccentChooserDialogFragment.java
+++ b/app/src/main/java/com/hardcodecoder/pulsemusic/dialog/CustomAccentChooserDialogFragment.java
@@ -1,0 +1,115 @@
+package com.hardcodecoder.pulsemusic.dialog;
+
+import android.graphics.PorterDuff;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import android.graphics.Color;
+import android.widget.ImageView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.res.ResourcesCompat;
+
+import com.google.android.material.button.MaterialButton;
+import com.hardcodecoder.pulsemusic.R;
+import com.google.android.material.slider.Slider;
+
+import java.util.Objects;
+
+public class CustomAccentChooserDialogFragment extends RoundedBottomSheetDialogFragment {
+
+    public static final String TAG = "CustomAccentChooser";
+    // Create component variables
+    private MaterialButton mPresets;
+    private EditText mHexCode;
+    private ImageView mColorPreview;
+    private Slider[] mSliders;
+
+    private int mSelectedColor;
+
+    public static CustomAccentChooserDialogFragment getInstance() {
+        return new CustomAccentChooserDialogFragment();
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.bottom_sheet_custom_accent_chooser, container, false);
+    }
+
+    private void createHexCode() {
+        int r = Math.round(mSliders[0].getValue());
+        int g = Math.round(mSliders[1].getValue());
+        int b = Math.round(mSliders[2].getValue());
+
+        int rgb = Color.rgb(r, g, b);
+        mSelectedColor = rgb;
+        mColorPreview.getDrawable().setColorFilter(mSelectedColor, PorterDuff.Mode.MULTIPLY);
+
+
+        mHexCode.setText(String.format("#%06X", (0xFFFFFF & rgb)));
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        // Get component paths
+        mPresets = view.findViewById(R.id.custom_accents_presets_btn);
+        mHexCode = view.findViewById(R.id.hex_code);
+        mColorPreview = view.findViewById(R.id.color_preview);
+        mSliders = new Slider[]{view.findViewById(R.id.red_slider), view.findViewById(R.id.green_slider), view.findViewById(R.id.blue_slider)};
+
+        // Button sends user back to presets
+        mPresets.setOnClickListener(v -> {
+            AccentsChooserDialogFragment dialogFragment = AccentsChooserDialogFragment.getInstance();
+            dialogFragment.show(Objects.requireNonNull(getActivity()).getSupportFragmentManager(), AccentsChooserDialogFragment.TAG);
+            dismiss();
+        });
+
+        // Add sliders' OnChangeListeners
+        for (Slider hexSlider : mSliders) {
+            hexSlider.addOnChangeListener((slider, value, fromUser) -> {
+                createHexCode();
+            });
+        }
+
+        // Hex text field
+        // This is probably inefficient, but it's the only way I knew
+        mHexCode.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                try {
+                    mSelectedColor = Color.parseColor(s.toString());
+                } catch (Exception e) {
+                    mHexCode.setBackgroundColor(ResourcesCompat.getColor(getResources(), R.color.md_red_A400, null));
+                    return;
+                }
+                mHexCode.setBackgroundColor(Color.argb(0, 0, 0, 0));
+                mColorPreview.getDrawable().setColorFilter(mSelectedColor, PorterDuff.Mode.MULTIPLY);
+            }
+        });
+
+        for (Slider hexSlider : mSliders) {
+            hexSlider.setLabelFormatter(value -> String.valueOf(Math.round(value)));
+        }
+
+
+        createHexCode();
+
+    }
+
+}

--- a/app/src/main/res/layout/bottom_sheet_accents_picker.xml
+++ b/app/src/main/res/layout/bottom_sheet_accents_picker.xml
@@ -28,6 +28,18 @@
         android:paddingEnd="0dp" />
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/choose_accents_custom_btn"
+        style="@style/MaterialTextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/accents_display_rv"
+        android:layout_alignParentStart="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="2dp"
+        android:layout_marginBottom="32dp"
+        android:text="@string/custom" />
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/choose_accents_cancel_btn"
         style="@style/MaterialTextButton"
         android:layout_width="wrap_content"
@@ -37,4 +49,5 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="32dp"
         android:text="@string/cancel" />
+
 </RelativeLayout>

--- a/app/src/main/res/layout/bottom_sheet_custom_accent_chooser.xml
+++ b/app/src/main/res/layout/bottom_sheet_custom_accent_chooser.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingTop="32dp">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="32dp"
+        android:layout_marginBottom="32dp"
+        android:gravity="start"
+        android:text="@string/custom_accent_title"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        android:textColor="?attr/primaryColor"
+        android:textStyle="bold" />
+
+    <LinearLayout
+        android:id="@+id/red_components"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:gravity="center_vertical"
+        android:layout_below="@id/title">
+
+        <TextView
+            android:id="@+id/red_label"
+            android:layout_width="16dp"
+            android:layout_height="wrap_content"
+            android:text="R"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+        <include
+            android:id="@+id/red_slider"
+            layout="@layout/color_channel_slider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/green_components"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:gravity="center_vertical"
+        android:layout_below="@id/red_components">
+
+        <TextView
+            android:id="@+id/green_label"
+            android:layout_width="16dp"
+            android:layout_height="wrap_content"
+            android:text="G"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+        <include
+            android:id="@+id/green_slider"
+            layout="@layout/color_channel_slider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            tools:value="128"
+            tools:valueFrom="0"
+            tools:valueTo="255" />
+    </LinearLayout>
+
+
+    <LinearLayout
+        android:id="@+id/blue_components"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="16dp"
+        android:gravity="center_vertical"
+        android:layout_below="@id/green_components">
+
+        <TextView
+            android:id="@+id/blue_label"
+            android:layout_width="16dp"
+            android:layout_height="wrap_content"
+            android:text="B"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+        <include
+            android:id="@+id/blue_slider"
+            layout="@layout/color_channel_slider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <EditText
+        android:id="@+id/hex_code"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/blue_components"
+        android:layout_centerHorizontal="true"
+        android:ems="10"
+        android:text="#808080"
+        android:inputType="text" />
+
+    <ImageView
+        android:id="@+id/color_preview"
+        android:layout_below="@id/hex_code"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:layout_marginTop="16dp"
+        android:layout_centerInParent="true"
+        app:srcCompat="@drawable/ic_app_shortcut_background" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/custom_accents_apply_btn"
+        style="@style/MaterialTextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/color_preview"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="32dp"
+        android:text="@string/apply" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/custom_accents_presets_btn"
+        style="@style/MaterialTextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/color_preview"
+        android:layout_alignParentStart="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="32dp"
+        android:text="@string/presets" />
+
+
+</RelativeLayout>

--- a/app/src/main/res/layout/color_channel_slider.xml
+++ b/app/src/main/res/layout/color_channel_slider.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.slider.Slider xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/color_channel_slider"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:value="128"
+    android:valueFrom="0"
+    android:valueTo="255"
+    app:thumbColor="?attr/primaryColor"
+    app:thumbRadius="10dp"
+    app:trackColorActive="?attr/primaryColor"
+    app:trackColorInactive="?attr/overlayColor" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,9 @@
     <string name="select_dark_theme">Set preferred dark theme</string>
     <string name="set">Set</string>
 
+    <string name="custom">Custom</string>
+    <string name="custom_accent_title">Adjust custom color</string>
+
 
     <!-- Now playing settings -->
     <string name="now_playing_album_style_section_title">Style</string>
@@ -258,4 +261,6 @@
 
     <string name="shortcut_suggested_label">For you</string>
     <string name="shortcut_suggested_label_long">For you</string>
+    <string name="apply">Apply</string>
+    <string name="presets">Presets</string>
 </resources>


### PR DESCRIPTION
I saw this app as a brilliant alternative to another music player I use, but it was missing a feature that I took for granted from the previous one: the ability to choose a custom UI accent colour.

In this PR I've made a mockup of a potential interface for such a feature, featuring sliders for R, G and B colour channels and a text input box for the user to enter a hex code. You can access it by going to Settings > Look and Feel > Pick accent color > Custom

As I'm new to Android development (I started yesterday :worried:) and somewhat rusty with Java, I'm looking for guidance on how to possibly implement the back-end code for this feature. Specifically:

- How to actually get the UI to change to the colour specified by the hex code
- Save the custom colour
- Save the fact that a custom colour is being used

I've looked into SharedPreferences, but I don't exactly know the desired format for this project specifically. Any help would be greatly appreciated here!

This is my first contribution to an existing FOSS project! Please point out anything I'm doing wrong so I can learn from it. :+1: 