### PR TITLE
Fixed null pointer exception

### DIFF
--- a/app/src/main/java/com/hardcodecoder/pulsemusic/PMS.java
+++ b/app/src/main/java/com/hardcodecoder/pulsemusic/PMS.java
@@ -178,7 +178,7 @@ public class PMS extends Service implements PlaybackManager.PlaybackServiceCallb
 
     @Override
     public void onTaskRemoved(Intent rootIntent) {
-        if (!mMediaSession.isActive()) stopSelf();
+        if (mMediaSession!=null && !mMediaSession.isActive()) stopSelf();
         super.onTaskRemoved(rootIntent);
     }
 


### PR DESCRIPTION
Android Version:
Android 10

Error:
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.media.session.MediaSession.isActive()' on a null object reference at com.hardcodecoder.pulsemusic.PMS.onTaskRemoved(PMS.java:181)